### PR TITLE
Hide the "Hosting Details" section

### DIFF
--- a/app/client/views/confirmation/confirmation.html
+++ b/app/client/views/confirmation/confirmation.html
@@ -130,6 +130,8 @@
           <br>
           <br>
 
+          <div style="display: none;">
+
           <div class="divided title">Hosting Details</div>
 
           <p>
@@ -197,6 +199,8 @@
 
           <br>
           <br>
+ 
+          </div>
 
           <div class="divided title">Travel</div>
           <div class="field">


### PR DESCRIPTION
Idea is to hide using custom styles and not Angular, so those values will still be sent with the form to the server.

See also: https://stackoverflow.com/a/18446441

PS: This change has not been tested on my side FYI